### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ Use go1.17 or later and build with `make`.
 With no options, the UI will be displayed instead of starting a service.
 
 ## Local Algod
+If you're using the downloaded binary, use `./node-ui` instead of `./nodeui`
 ```
 ~$ ALGORAND_DATA=path/to/data/dir ./nodeui
 ```
 ## Remote Algod
+If you're using the downloaded binary, use `./node-ui` instead of `./nodeui`
 ```
 ~$ ./nodeui -t <algod api token> -u http://<url>
 ```


### PR DESCRIPTION
## Summary

Noticed that if we run `make` from source, it names the app `nodeui`, but the downloaded packages from the releases page name the file `node-ui`. I thought I'd just update the difference on the README.